### PR TITLE
feat(core): synonymize "open" and "connect to"

### DIFF
--- a/pkg/core/src/parser.ts
+++ b/pkg/core/src/parser.ts
@@ -3,6 +3,7 @@ import {
 	And,
 	Buzzword,
 	Connect,
+	Open,
 	Identifier,
 	Into,
 	Output,
@@ -14,14 +15,14 @@ import { CstParser, type IToken, type CstNode } from '@slangroom/deps/chevrotain
 
 export type StatementCst = CstNode & {
 	children: {
-		connect?: ConnectCst;
+		openconnect?: OpenconnectCst;
 		sendpass: SendpassCst[];
 		phrase: PhraseCst;
 		into?: IntoCst;
 	};
 };
 
-export type ConnectCst = CstNode & {
+export type OpenconnectCst = CstNode & {
 	children: { Identifier: [IToken] };
 };
 
@@ -49,15 +50,22 @@ const Parser = new (class extends CstParser {
 	}
 
 	statement = this.RULE('statement', () => {
-		this.OPTION1(() => this.SUBRULE(this.#connect));
+		this.OPTION1(() => this.SUBRULE(this.#openconnect));
 		this.MANY(() => this.SUBRULE(this.#sendpass));
 		this.SUBRULE(this.#phrase);
 		this.OPTION2(() => this.SUBRULE(this.#into));
 	});
 
-	#connect = this.RULE('connect', () => {
-		this.CONSUME(Connect);
-		this.CONSUME(To);
+	#openconnect = this.RULE('openconnect', () => {
+		this.OR([
+			{ ALT: () => this.CONSUME(Open) },
+			{
+				ALT: () => {
+					this.CONSUME(Connect);
+					this.CONSUME(To);
+				},
+			},
+		]);
 		this.CONSUME(Identifier);
 		this.CONSUME(And);
 	});

--- a/pkg/core/src/plugin.ts
+++ b/pkg/core/src/plugin.ts
@@ -248,9 +248,17 @@ export class PluginContextTest implements PluginContext {
 	/**
 	 * @constructor
 	 */
-	static openconnect(openconnect: string | string[]) {
-		return new this(openconnect, {});
+	static open(open: string | string[]) {
+		return new this(open, {});
 	}
+
+	/**
+	 * @constructor
+	 */
+	static connect(connect: string | string[]) {
+		return new this(connect, {});
+	}
+
 
 	/**
 	 * @constructor

--- a/pkg/core/src/tokens.ts
+++ b/pkg/core/src/tokens.ts
@@ -18,6 +18,11 @@ export const Connect = createToken({
 	pattern: /connect/i,
 });
 
+export const Open = createToken({
+	name: 'Open',
+	pattern: /open/i,
+});
+
 export const To = createToken({
 	name: 'To',
 	pattern: /to/i,
@@ -51,6 +56,7 @@ export const And = createToken({
 export const allTokens = [
 	Whitespace,
 	Connect,
+	Open,
 	Into,
 	Output,
 	And,

--- a/pkg/core/src/visitor.ts
+++ b/pkg/core/src/visitor.ts
@@ -4,12 +4,12 @@ import {
 	type PhraseCst,
 	type IntoCst,
 	type SendpassCst,
-	type ConnectCst,
+	type OpenconnectCst,
 } from '@slangroom/core';
 import type { IToken } from '@slangroom/deps/chevrotain';
 
 export type Statement = {
-	connect?: string;
+	openconnect?: string;
 	bindings: Map<string, string>;
 	phrase: string;
 	into?: string;
@@ -27,7 +27,7 @@ interface V {
 	visit(cst: StatementCst): ReturnType<this['statement']>;
 	visit(cst: PhraseCst): ReturnType<this['phrase']>;
 	visit(cst: SendpassCst): ReturnType<this['sendpass']>;
-	visit(cst: ConnectCst): ReturnType<this['connect']>;
+	visit(cst: OpenconnectCst): ReturnType<this['openconnect']>;
 	visit(cst: IntoCst): ReturnType<this['into']>;
 }
 
@@ -47,7 +47,7 @@ class V extends CstVisitor {
 			if (stmt.bindings.has(key)) throw new ErrorKeyExists(key);
 			stmt.bindings.set(key, value);
 		});
-		if (ctx.connect) stmt.connect = this.visit(ctx.connect);
+		if (ctx.openconnect) stmt.openconnect = this.visit(ctx.openconnect);
 		if (ctx.into) stmt.into = this.visit(ctx.into);
 		return stmt;
 	}
@@ -60,7 +60,7 @@ class V extends CstVisitor {
 		return [this.visit(ctx.phrase), ctx.Identifier[0].image.slice(1, -1)];
 	}
 
-	connect(ctx: ConnectCst['children']): string {
+	openconnect(ctx: OpenconnectCst['children']): string {
 		return ctx.Identifier[0].image.slice(1, -1);
 	}
 

--- a/pkg/core/test/slangroom.ts
+++ b/pkg/core/test/slangroom.ts
@@ -5,6 +5,8 @@ test('runs all unknown statements', async (t) => {
 	let usedP0 = false;
 	let usedP1 = false;
 	let usedP2 = false;
+	let usedP3 = false;
+	let usedP4 = false;
 
 	const p0 = (ctx: PluginContext): PluginResult => {
 		if (ctx.phrase === 'a') {
@@ -32,6 +34,25 @@ test('runs all unknown statements', async (t) => {
 		return ctx.fail('Unkown phrase');
 	};
 
+	const p3 = (ctx: PluginContext): PluginResult => {
+		if (ctx.phrase === 'e f') {
+			usedP3 = true;
+			t.is(ctx.fetchOpen()[0], 'bar');
+			return ctx.pass(null);
+		}
+		return ctx.fail('Unkown phrase');
+	};
+
+	const p4 = (ctx: PluginContext): PluginResult => {
+		if (ctx.phrase === 'f g') {
+			usedP4 = true;
+			t.is(ctx.fetchConnect()[0], 'foo');
+			return ctx.pass(null);
+		}
+		return ctx.fail('Unkown phrase');
+	};
+
+
 	const script = `
 Rule caller restroom-mw
 Given I A and output into 'a'
@@ -42,11 +63,15 @@ Then print 'a'
 Then I pass a 'a' and B and output into 'b'
 Then I pass a 'b' and  c D
 Then I pass a 'b' and  C d and output into 'mimmo'
+Then I open 'b' and e F
+Then I connect to 'a' and F g
 `;
-	const slangroom = new Slangroom(p0, [p1, new Set([p2])]);
+	const slangroom = new Slangroom(p0, [p1, new Set([p2]), p3], p4);
 	const res = await slangroom.execute(script);
 	t.true(usedP0);
 	t.true(usedP1);
 	t.true(usedP2);
+	t.true(usedP3);
+	t.true(usedP4);
 	t.deepEqual(res.result, { a: 'foo', b: 'bar', mimmo: 'foobar' }, res.logs);
 });

--- a/pkg/core/test/visitor.ts
+++ b/pkg/core/test/visitor.ts
@@ -21,29 +21,29 @@ test('generated ast is correct', async (t) => {
 			]),
 		},
 		"connect to 'foo' and read the    ethereum		 balance": {
-			connect: 'foo',
+			openconnect: 'foo',
 			phrase: 'read the ethereum balance',
 			bindings: new Map<string, string>(),
 		},
 		"connect to 'foo' and pass address 'addr'  and send contract 'contract' and read the    ethereum		 balance":
-			{
-				connect: 'foo',
-				phrase: 'read the ethereum balance',
-				bindings: new Map<string, string>([
-					['address', 'addr'],
-					['contract', 'contract'],
-				]),
-			},
-		"connect to 'foo' and pass address 'addr'  and send contract 'contract' and read the    ethereum		 balance and output into 'var'":
-			{
-				connect: 'foo',
-				phrase: 'read the ethereum balance',
-				bindings: new Map<string, string>([
-					['address', 'addr'],
-					['contract', 'contract'],
-				]),
-				into: 'var',
-			},
+		{
+			openconnect: 'foo',
+			phrase: 'read the ethereum balance',
+			bindings: new Map<string, string>([
+				['address', 'addr'],
+				['contract', 'contract'],
+			]),
+		},
+		"open 'foo' and pass address 'addr'  and send contract 'contract' and read the    ethereum		 balance and output into 'var'":
+		{
+			openconnect: 'foo',
+			phrase: 'read the ethereum balance',
+			bindings: new Map<string, string>([
+				['address', 'addr'],
+				['contract', 'contract'],
+			]),
+			into: 'var',
+		},
 	};
 
 	for (const [line, astWant] of Object.entries(cases)) {

--- a/pkg/http/test/plugins.ts
+++ b/pkg/http/test/plugins.ts
@@ -40,7 +40,7 @@ test('Simple GET', async (t) => {
 		return;
 	}
 
-	const ctx = PluginContextTest.connect('http://localhost/normaljson');
+	const ctx = PluginContextTest.openconnect('http://localhost/normaljson');
 	const res = await execute(ctx, ast.kind, ast.method);
 	t.deepEqual(res, {
 		ok: true,

--- a/pkg/http/test/plugins.ts
+++ b/pkg/http/test/plugins.ts
@@ -40,7 +40,7 @@ test('Simple GET', async (t) => {
 		return;
 	}
 
-	const ctx = PluginContextTest.openconnect('http://localhost/normaljson');
+	const ctx = PluginContextTest.connect('http://localhost/normaljson');
 	const res = await execute(ctx, ast.kind, ast.method);
 	t.deepEqual(res, {
 		ok: true,


### PR DESCRIPTION
Now, "open" and "connect to" are synonyms.  Added two new method signature to PluginContext as well, getOpen() and fetchOpen(), which are synonyms to getOpen() and fetchOpen() too.