### PR TITLE
build: remove cjs support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: 🧪 Lint and test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 concurrency:

--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
 		"coverage": "c8 -r text -r lcov -o .coverage --exclude '**/test/' pnpm test",
 		"clean": "rm -rf .coverage && pnpm -F @slangroom/* exec -- rm -rf build",
 		"docs": "node docs/generate_syntax.mjs",
-		"build": "pnpm build:esm",
-		"build:dual": "pnpm build:esm && pnpm build:cjs",
-		"build:cjs": "pnpm -F @slangroom/* exec tsc --outDir build/cjs --module commonjs && pnpm cjs-fixup",
-		"build:esm": "pnpm -F @slangroom/* exec tsc --outdir build/esm --module node16",
-		"build-all": "pnpm build:dual",
-		"cjs-fixup": "pnpm -F @slangroom/* exec sh -c \"echo '{\\\"type\\\":\\\"commonjs\\\"}' >build/cjs/package.json\"",
+		"build": "pnpm -F @slangroom/* exec tsc --outdir build/esm --module node16",
 		"publish:ci": "lerna version --no-changelog --conventional-commits --yes && pnpm publish -r --no-git-checks"
 	},
 	"devDependencies": {

--- a/pkg/browser/package.json
+++ b/pkg/browser/package.json
@@ -8,27 +8,19 @@
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
 	"type": "module",
-	"main": "./build/cjs/src/index.js",
-	"types": "./build/cjs/src/index.d.ts",
+	"main": "./build/esm/src/index.js",
+	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
 			"import": {
 				"types": "./build/esm/src/index.d.ts",
 				"default": "./build/esm/src/index.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/index.d.ts",
-				"default": "./build/cjs/src/index.js"
 			}
 		},
 		"./*": {
 			"import": {
 				"types": "./build/esm/src/*.d.ts",
 				"default": "./build/esm/src/*.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/*.d.ts",
-				"default": "./build/cjs/src/*.js"
 			}
 		}
 	},

--- a/pkg/browser/package.json
+++ b/pkg/browser/package.json
@@ -33,6 +33,6 @@
 		"esbuild": "^0.18.4"
 	},
 	"scripts": {
-		"build": "pnpm exec esbuild --bundle src/index.ts --outfile=public/slangroom.js --external:fs --external:path --external:crypto"
+		"build": "pnpm exec esbuild --bundle src/index.ts --outfile=public/slangroom.js --target=es2016 --external:fs --external:path --external:crypto"
 	}
 }

--- a/pkg/browser/src/index.ts
+++ b/pkg/browser/src/index.ts
@@ -5,4 +5,4 @@ const slangroom = new Slangroom(http);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).slangroom = slangroom; // instead of casting window to any, you can extend the Window interface: https://stackoverflow.com/a/43513740/5433572
 
-console.log('slangroom object initialized');
+console.log('🎉 Slangroom is ready');

--- a/pkg/core/package.json
+++ b/pkg/core/package.json
@@ -9,27 +9,19 @@
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
 	"type": "module",
-	"main": "./build/cjs/src/index.js",
-	"types": "./build/cjs/src/index.d.ts",
+	"main": "./build/esm/src/index.js",
+	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
 			"import": {
 				"types": "./build/esm/src/index.d.ts",
 				"default": "./build/esm/src/index.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/index.d.ts",
-				"default": "./build/cjs/src/index.js"
 			}
 		},
 		"./*": {
 			"import": {
 				"types": "./build/esm/src/*.d.ts",
 				"default": "./build/esm/src/*.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/*.d.ts",
-				"default": "./build/cjs/src/*.js"
 			}
 		}
 	},

--- a/pkg/deps/package.json
+++ b/pkg/deps/package.json
@@ -10,27 +10,19 @@
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
 	"type": "module",
-	"main": "./build/cjs/src/index.js",
-	"types": "./build/cjs/src/index.d.ts",
+	"main": "./build/esm/src/index.js",
+	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
 			"import": {
 				"types": "./build/esm/src/index.d.ts",
 				"default": "./build/esm/src/index.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/index.d.ts",
-				"default": "./build/cjs/src/index.js"
 			}
 		},
 		"./*": {
 			"import": {
 				"types": "./build/esm/src/*.d.ts",
 				"default": "./build/esm/src/*.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/*.d.ts",
-				"default": "./build/cjs/src/*.js"
 			}
 		}
 	},

--- a/pkg/ethereum/package.json
+++ b/pkg/ethereum/package.json
@@ -11,27 +11,19 @@
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
 	"type": "module",
-	"main": "./build/cjs/src/index.js",
-	"types": "./build/cjs/src/index.d.ts",
+	"main": "./build/esm/src/index.js",
+	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
 			"import": {
 				"types": "./build/esm/src/index.d.ts",
 				"default": "./build/esm/src/index.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/index.d.ts",
-				"default": "./build/cjs/src/index.js"
 			}
 		},
 		"./*": {
 			"import": {
 				"types": "./build/esm/src/*.d.ts",
 				"default": "./build/esm/src/*.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/*.d.ts",
-				"default": "./build/cjs/src/*.js"
 			}
 		}
 	},

--- a/pkg/http/package.json
+++ b/pkg/http/package.json
@@ -9,27 +9,19 @@
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
 	"type": "module",
-	"main": "./build/cjs/src/index.js",
-	"types": "./build/cjs/src/index.d.ts",
+	"main": "./build/esm/src/index.js",
+	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
 			"import": {
 				"types": "./build/esm/src/index.d.ts",
 				"default": "./build/esm/src/index.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/index.d.ts",
-				"default": "./build/cjs/src/index.js"
 			}
 		},
 		"./*": {
 			"import": {
 				"types": "./build/esm/src/*.d.ts",
 				"default": "./build/esm/src/*.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/*.d.ts",
-				"default": "./build/cjs/src/*.js"
 			}
 		}
 	},

--- a/pkg/ignored/package.json
+++ b/pkg/ignored/package.json
@@ -8,27 +8,19 @@
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
 	"type": "module",
-	"main": "./build/cjs/src/index.js",
-	"types": "./build/cjs/src/index.d.ts",
+	"main": "./build/esm/src/index.js",
+	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
 			"import": {
 				"types": "./build/esm/src/index.d.ts",
 				"default": "./build/esm/src/index.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/index.d.ts",
-				"default": "./build/cjs/src/index.js"
 			}
 		},
 		"./*": {
 			"import": {
 				"types": "./build/esm/src/*.d.ts",
 				"default": "./build/esm/src/*.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/*.d.ts",
-				"default": "./build/cjs/src/*.js"
 			}
 		}
 	},

--- a/pkg/shared/package.json
+++ b/pkg/shared/package.json
@@ -7,27 +7,19 @@
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
 	"type": "module",
-	"main": "./build/cjs/src/index.js",
-	"types": "./build/cjs/src/index.d.ts",
+	"main": "./build/esm/src/index.js",
+	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
 			"import": {
 				"types": "./build/esm/src/index.d.ts",
 				"default": "./build/esm/src/index.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/index.d.ts",
-				"default": "./build/cjs/src/index.js"
 			}
 		},
 		"./*": {
 			"import": {
 				"types": "./build/esm/src/*.d.ts",
 				"default": "./build/esm/src/*.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/*.d.ts",
-				"default": "./build/cjs/src/*.js"
 			}
 		}
 	},

--- a/pkg/wallet/package.json
+++ b/pkg/wallet/package.json
@@ -12,27 +12,19 @@
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
 	"type": "module",
-	"main": "./build/cjs/src/index.js",
-	"types": "./build/cjs/src/index.d.ts",
+	"main": "./build/esm/src/index.js",
+	"types": "./build/esm/src/index.d.ts",
 	"exports": {
 		".": {
 			"import": {
 				"types": "./build/esm/src/index.d.ts",
 				"default": "./build/esm/src/index.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/index.d.ts",
-				"default": "./build/cjs/src/index.js"
 			}
 		},
 		"./*": {
 			"import": {
 				"types": "./build/esm/src/*.d.ts",
 				"default": "./build/esm/src/*.js"
-			},
-			"require": {
-				"types": "./build/cjs/src/*.d.ts",
-				"default": "./build/cjs/src/*.js"
 			}
 		}
 	},


### PR DESCRIPTION
The browser module bundles everything correctly with ebuild
no need for cjs for nodejs that supports esm by default
