### PR TITLE
fix!(core/plugin): enforce sanity of params and phrase

### DIFF
--- a/pkg/core/src/plugin.ts
+++ b/pkg/core/src/plugin.ts
@@ -161,7 +161,7 @@ export class Plugin {
  * @param str The input to be checked for sanity.
  * @returns whether it is sane or not.
  */
-export const isSane = (str: string) => /^[a-z]([a-z0-9]+|[a-z0-9]+[_-][a-z0-9]+)*$/.test(str);
+export const isSane = (str: string) => /^[a-z][a-z0-9]*([_-][a-z0-9]+)*$/.test(str);
 
 // Todo: Maybe we should adapt some sort of monad library.
 

--- a/pkg/core/src/plugin.ts
+++ b/pkg/core/src/plugin.ts
@@ -115,20 +115,21 @@ export class Plugin {
 			throw new Error('unreachable');
 		}
 
-		// TODO: allow dashes and underscores only in between words
-		if (phrase.split(' ').some((x) => !x.match(/^[0-9a-z_-]+$/)))
+		if (phrase.split(' ').some((x) => !isSane(x)))
 			throw new Error(
-				'phrase must composed of alpha-numerical, underscore, and dash values split by a single space',
+				'phrase must be composed of alpha-numerical, underscore, and dash values split by a single space',
 			);
 
 		const key: PluginMapKey = { phrase: phrase };
 		if (openconnect) key.openconnect = openconnect;
 		if (params) {
-			// TODO: allow dashes and underscores and only in between words
-			if (params.some((x) => !x.match(/^[0-9a-z_-]+$/)))
+			// TODO: allow spaces in params
+			const found = params.find((x) => !isSane(x));
+			if (found !== undefined)
 				throw new Error(
-					'each params must composed of alpha-numerical values, optionally split by dashes or underscores',
+					`the following parameter must be composed of alpha-numerical values, optionally split by dashes or underscores: ${found}`,
 				);
+
 			const duplicates = [
 				...params.reduce((acc, cur) => {
 					const found = acc.get(cur);
@@ -148,6 +149,19 @@ export class Plugin {
 		return executor;
 	}
 }
+
+/**
+ * @internal
+ * Check the sanity of a Phrase or Param for the following:
+ *
+ * 1. Must start with a letter.
+ * 2. Dashes and underscores are allowed only inbetween words once.
+ * 3. Must be composed solely of letter, digits, dashes, and underscores.
+ *
+ * @param str The input to be checked for sanity.
+ * @returns whether it is sane or not.
+ */
+export const isSane = (str: string) => /^[a-z]([a-z0-9]+|[a-z0-9]+[_-][a-z0-9]+)*$/.test(str);
 
 // Todo: Maybe we should adapt some sort of monad library.
 

--- a/pkg/core/test/plugin.ts
+++ b/pkg/core/test/plugin.ts
@@ -40,9 +40,17 @@ test('Plugin.new() phrase alpha-numerical checks work', (t) => {
 		}),
 	);
 
-	['foo', 'foo bar', 'foo_bar', 'foo-bar', 'foo bar baz', 'foo_bar_baz', 'foo-bar-baz'].forEach(
-		(x) => t.notThrows(() => new Plugin().new(x, (ctx) => ctx.pass(null)), x),
-	);
+	[
+		'foo',
+		'foo bar',
+		'foo_bar',
+		'foo-bar',
+		'foo bar baz',
+		'foo_bar_baz',
+		'foo-bar-baz',
+		'p-p',
+		'p-256',
+	].forEach((x) => t.notThrows(() => new Plugin().new(x, (ctx) => ctx.pass(null)), x));
 });
 
 test('Plugin.new() params alpha-numerical checks work', (t) => {
@@ -57,58 +65,52 @@ test('Plugin.new() params alpha-numerical checks work', (t) => {
 		),
 	);
 
-	['foo', 'foo_bar', 'foo-bar', 'foo_bar_baz', 'foo-bar-baz'].forEach((x) => {
+	['foo', 'foo_bar', 'foo-bar', 'foo_bar_baz', 'foo-bar-baz', 'p-p', 'p-256'].forEach((x) => {
 		t.notThrows(() => new Plugin().new(x, (ctx) => ctx.pass(null)), x);
 	});
 });
 
 test('Plugin.new() duplicates detected', (t) => {
 	const f: PluginExecutor = (ctx) => ctx.pass(null);
-	t.is(
-		(
-			t.throws(
-				() => {
-					const p = new Plugin();
-					p.new('a', f);
-					p.new('a', f);
-				},
-				{ instanceOf: DuplicatePluginError },
-			) as DuplicatePluginError
-		).message,
-		`duplicated plugin with key: openconnect= params= phrase="a"`,
+	t.throws(
+		() => {
+			const p = new Plugin();
+			p.new('a', f);
+			p.new('a', f);
+		},
+		{
+			instanceOf: DuplicatePluginError,
+			message: `duplicated plugin with key: openconnect= params= phrase="a"`,
+		},
 	);
 
-	t.is(
-		(
-			t.throws(
-				() => {
-					const p = new Plugin();
-					p.new('a', f);
-					p.new('open', 'a', f);
-					p.new('open', 'a', f);
-				},
-				{ instanceOf: DuplicatePluginError },
-			) as DuplicatePluginError
-		).message,
-		`duplicated plugin with key: openconnect=open params= phrase="a"`,
+	t.throws(
+		() => {
+			const p = new Plugin();
+			p.new('a', f);
+			p.new('open', 'a', f);
+			p.new('open', 'a', f);
+		},
+		{
+			instanceOf: DuplicatePluginError,
+			message: `duplicated plugin with key: openconnect=open params= phrase="a"`,
+		},
 	);
 
-	t.is(
-		(
-			t.throws(
-				() => {
-					const p = new Plugin();
-					p.new('a', f);
-					p.new('open', 'a', f);
-					p.new('connect', 'a', f);
-					p.new('open', ['foo'], 'a', f);
-					p.new('connect', ['foo'], 'a', f);
-					p.new('connect', ['foo'], 'a', f);
-				},
-				{ instanceOf: DuplicatePluginError },
-			) as DuplicatePluginError
-		).message,
-		`duplicated plugin with key: openconnect=connect params=foo phrase="a"`,
+	t.throws(
+		() => {
+			const p = new Plugin();
+			p.new('a', f);
+			p.new('open', 'a', f);
+			p.new('connect', 'a', f);
+			p.new('open', ['foo'], 'a', f);
+			p.new('connect', ['foo'], 'a', f);
+			p.new('connect', ['foo'], 'a', f);
+		},
+		{
+			instanceOf: DuplicatePluginError,
+			message: `duplicated plugin with key: openconnect=connect params=foo phrase="a"`,
+		},
 	);
 });
 


### PR DESCRIPTION
Allow dashes and underscores and only in between words of phrases or each of params.  The next fix should be done on params again to allow spaces in between words.