### PR TITLE
feat(oauth): new statements for authorization_details and request_uri

### DIFF
--- a/pkg/oauth/src/model.ts
+++ b/pkg/oauth/src/model.ts
@@ -161,6 +161,20 @@ export class InMemoryCache implements AuthorizationCodeModel {
 
 	getAuthorizationDetails(authorizationCode: string) {
 		const auth_details = this.authorization_details.get(authorizationCode);
+		if (!auth_details) throw new OAuthError("Failed to get authorization_details: given authorization_code is not valid");
+		return auth_details;
+	}
+
+	updateAuthorizationDetails(request_uri: string, data: any) {
+		const base_uri = "urn:ietf:params:oauth:request_uri:";
+		const rand_uri = request_uri.replace(base_uri, "");
+		const auth_code = this.getAuthCodeFromUri(rand_uri);
+		let auth_details = this.getAuthorizationDetails(auth_code.authorizationCode);
+		//TODO: case of multiple elem in auth_details
+		if (auth_details[0]) {
+			auth_details[0]['claims'] = data;
+		}
+		this.authorization_details.set(auth_code.authorizationCode, auth_details);
 		return auth_details;
 	}
 

--- a/pkg/oauth/src/plugin.ts
+++ b/pkg/oauth/src/plugin.ts
@@ -75,6 +75,17 @@ const getAuthenticateHandler = (model: InMemoryCache, authenticationUrl: string)
  */
 
 //Sentence that allows to generate and output a valid access token from an auth server backend
+/**
+Given I send request 'request' and send server_data 'server' and generate access token and output into 'accessToken_jwt'
+Input:
+	request: MUST be a string dictionary with keys `header` and `body` of a request to the /token endpoint
+	server_data: MUST be a string dictionary with keys
+			jwk: JWK containing the public key of the authorization_server
+			url: url of the authorization_server
+			authentication_url: did resolver for client pk
+Output:
+	accessToken_jwt: string dictionary containing the access token JWT
+*/
 export const createToken = p.new(
 	['request', 'server_data'],
 	'generate access token',
@@ -144,7 +155,16 @@ export const createToken = p.new(
 /**
  * @internal
  */
-// Sentence that allows to verify the parameters of the /authorize request
+// Sentence that allows to verify the parameters (request_uri and client_id) of an /authorize request
+/**
+Given I send request 'request' and send server_data 'server' and verify request parameters
+Input:
+	request: MUST be a string dictionary with keys `header` and `body` of a request to the /authorize endpoint
+	server_data: MUST be a string dictionary with keys
+			jwk: JWK containing the public key of the authorization_server
+			url: url of the authorization_server
+			authentication_url: did resolver for client pk
+*/
 export const verifyRequestUri = p.new(
 	['request', 'server_data'],
 	'verify request parameters',
@@ -192,6 +212,17 @@ export const verifyRequestUri = p.new(
  * @internal
  */
 // Sentence that allows to generate and output a valid authorization code for an authenticated request
+/**
+Given I send request 'request' and send server_data 'server' and generate authorization code and output into 'authCode'
+Input:
+	request: MUST be a string dictionary with keys `header` and `body` of a request to the /authorize endpoint
+	server_data: MUST be a string dictionary with keys
+			jwk: JWK containing the public key of the authorization_server
+			url: url of the authorization_server
+			authentication_url: did resolver for client pk
+Output:
+	authCode: string dictionary {code: 'authorization_code'}
+*/
 export const createAuthorizationCode = p.new(
 	['request', 'server_data'],
 	'generate authorization code',
@@ -242,6 +273,21 @@ export const createAuthorizationCode = p.new(
  * @internal
  */
 //Sentence that perform a Pushed Authorization Request and return a valid request_uri (and expires_in)
+/**
+Given I send request 'request' and send client 'client' and send server_data 'server' and send expires_in 'expires_in' and generate request uri and output into 'request_uri_out'
+Input:
+	request: MUST be a string dictionary with keys `header` and `body` of a request to the /par endpoint
+	server_data: MUST be a string dictionary with keys
+			jwk: JWK containing the public key of the authorization_server
+			url: url of the authorization_server
+			authentication_url: did resolver for client pk
+	client: string dictionary
+
+Output:
+	request_uri_out: string dictionary with keys
+			request_uri: string
+			expires_in: number
+*/
 export const createRequestUri = p.new(
 	['request', 'client', 'server_data', 'expires_in'],
 	'generate request uri',
@@ -296,6 +342,17 @@ export const createRequestUri = p.new(
  * @internal
  */
 //Sentence that given an access token return the authorization_details
+/**
+Given I send token 'token' and send server_data 'server' and get claims from token and output into 'claims'
+Input:
+	server_data: MUST be a string dictionary with keys
+			jwk: JWK containing the public key of the authorization_server
+			url: url of the authorization_server
+			authentication_url: did resolver for client pk
+	token: MUST be a string representing a valid access_token
+Output:
+	claims: string array of the authorization_details linked to the access_token (without `locations` and `credentail_configuration_id`)
+*/
 export const getClaims = p.new(
 	['token', 'server_data'],
 	'get claims from token',
@@ -326,9 +383,20 @@ export const getClaims = p.new(
  * @internal
  */
 // Sentence that allows to add a string dict(?) to the authorization_details binded to the given request_uri
+/**
+Given I send request_uri 'request_uri' and send data 'data' and send server_data 'server' and add data to authorization details and output into 'auth_details'
+Input:
+	server_data: MUST be a string dictionary with keys
+			jwk: JWK containing the public key of the authorization_server
+			url: url of the authorization_server
+			authentication_url: did resolver for client pk
+	request_uri: MUST be a string (output of a /par request)
+Output:
+	auth_details: (optional) string dictionary of the authorization_details linked to the request_uri
+*/
 export const changeAuthDetails = p.new(
 	['request_uri', 'data', 'server_data'],
-	'add data to authorization_details',
+	'add data to authorization details',
 	async (ctx) => {
 		const params = ctx.fetch('data') as JsonableObject;
 		const uri = ctx.fetch('request_uri') as string;

--- a/pkg/oauth/test/e2e.ts
+++ b/pkg/oauth/test/e2e.ts
@@ -121,7 +121,7 @@ Then print the 'request_uri'
 Rule unknown ignore
 
 Given I send request 'request' and send server_data 'server' and verify request parameters
-Given I send request_uri 'request_uri' and send data 'data' and send server_data 'server' and add data to authorization_details and output into 'auth_details'
+Given I send request_uri 'request_uri' and send data 'data' and send server_data 'server' and add data to authorization details and output into 'auth_details'
 Given I send request 'request' and send server_data 'server' and generate authorization code and output into 'authCode'
 
 Given I have a 'string array' named 'auth_details'

--- a/pkg/oauth/test/e2e.ts
+++ b/pkg/oauth/test/e2e.ts
@@ -7,7 +7,7 @@ import { Slangroom } from '@slangroom/core';
 import { oauth } from '@slangroom/oauth';
 import { SignJWT, importJWK } from 'jose';
 import { randomBytes } from 'crypto';
-import { JsonableObject } from '@slangroom/shared';
+import { JsonableObject, JsonableArray } from '@slangroom/shared';
 
 //For reference see Section 4 of https://datatracker.ietf.org/doc/html/rfc9449.html
 async function create_dpop_proof() {
@@ -75,8 +75,7 @@ Then print data
 			},
 			request: {
 				//&scope=Auth1&resource=http%3A%2F%2Fissuer1.zenswarm.forkbomb.eu%3A3100%2Fcredential_issuer%2F
-				//authorization_details=%5B%7B%22type%22%3A%20%22openid_credential%22%2C%20%22credential_configuration_id%22%3A%20%22Auth1%22%2C%22locations%22%3A%20%5B%22http%3A%2F%2Fissuer1.zenswarm.forkbomb.eu%3A3100%2Fcredential_issuer%2F%22%5D%7D%5D
-				body: 'response_type=code&client_id=did:dyne:sandbox.genericissuer:6Cp8mPUvJmQaMxQPSnNyhb74f9Ga4WqfXCkBneFgikm5&state=xyz&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&redirect_uri=https%3A%2F%2FWallet.example.org%2Fcb&authorization_details=%5B%7B%22type%22%3A+%22openid_credential%22%2C+%22credential_configuration_id%22%3A+%22Auth1%22%2C%22locations%22%3A+%5B%22http%3A%2F%2Fissuer1.zenswarm.forkbomb.eu%3A3100%2Fcredential_issuer%2F%22%5D%2C%22given_name%22%3A%22Pippo%22%2C+%22family_name%22%3A%22Peppe%22%2C%22is_human%22%3Atrue%7D%5D',
+				body: 'response_type=code&client_id=did:dyne:sandbox.genericissuer:6Cp8mPUvJmQaMxQPSnNyhb74f9Ga4WqfXCkBneFgikm5&state=xyz&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&redirect_uri=https%3A%2F%2FWallet.example.org%2Fcb&authorization_details=%5B%7B%22type%22%3A+%22openid_credential%22%2C+%22credential_configuration_id%22%3A+%22Auth1%22%2C%22locations%22%3A+%5B%22http%3A%2F%2Fissuer1.zenswarm.forkbomb.eu%3A3100%2Fcredential_issuer%2F%22%5D%7D%5D',
 				headers: {
 					Authorization: '',
 				},
@@ -93,7 +92,7 @@ Then print data
 			},
 		},
 	});
-	//console.log(res.result['request_uri_out']);
+
 	t.truthy(res.result['request_uri_out']);
 
 	const scriptCreateBodyRequest1 = `
@@ -105,8 +104,10 @@ Given I have a 'string dictionary' named 'request_uri_out'
 When I create the copy of 'request_uri' from dictionary 'request_uri_out'
 # TODO: check if we need encoding before append
 When I append 'copy' to 'body'
+When I rename 'copy' to 'request_uri'
 
 Then print the 'body'
+Then print the 'request_uri'
 `;
 	const resb = await slangroom.execute(scriptCreateBodyRequest1, {
 		keys: {
@@ -119,8 +120,11 @@ Then print the 'body'
 	const scriptAuthCode = `
 Rule unknown ignore
 
+Given I send request 'request' and send server_data 'server' and verify request parameters
+Given I send request_uri 'request_uri' and send data 'data' and send server_data 'server' and add data to authorization_details and output into 'auth_details'
 Given I send request 'request' and send server_data 'server' and generate authorization code and output into 'authCode'
 
+Given I have a 'string array' named 'auth_details'
 Given I have a 'string dictionary' named 'authCode'
 
 Then print data
@@ -144,11 +148,19 @@ Then print data
 				headers: {
 					Authorization: '',
 				},
+			},
+			request_uri: resb.result['request_uri'] || '',
+			data: {
+				email_address: 'pippo@pippo.com'
 			}
 		},
 	});
-	//console.log(res_auth.result['authCode']);
+
 	t.truthy(res_auth.result['authCode']);
+	t.truthy(res_auth.result['auth_details']);
+	let authDet = res_auth.result['auth_details']! as JsonableArray;
+	let authDet_dict = authDet[0]! as JsonableObject;
+	t.truthy(authDet_dict['claims']);
 
 	const scriptCreateBodyRequest = `
 Rule unknown ignore
@@ -202,7 +214,7 @@ Then print data
 			},
 		},
 	});
-	//console.log(res3.result['accessToken_jwt']);
+
 	t.truthy(res3.result['accessToken_jwt']);
 	const scriptGetClaims = `
 Rule unknown ignore
@@ -223,7 +235,7 @@ Then print data
 			token: token_str
 		},
 	});
-	//console.log(res4.result['claims']);
+
 	t.truthy(res4.result['claims']);
 
 });


### PR DESCRIPTION
The first new statement looks like
`Given I send request 'request' and send server_data 'server' and verify request parameters`
given the parameters of an /authorize request, it checks the validity of the given `request_uri` and `client_id` in `request`.

The second statement looks like
`Given I send request_uri 'request_uri' and send data 'data' and send server_data 'server' and add data to authorization_details and output into 'auth_details'`
given a `request_uri` and a string dictionary `data`, it updates the `authorization_details` linked to the `request_uri` adding a new field `claims` that contains the dictionary `data`.