### PR TITLE
fix: use chalk to style error message insted of using directly ansi escape codes

### DIFF
--- a/pkg/core/src/lexer.ts
+++ b/pkg/core/src/lexer.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // read the version from the package.json
 import packageJson from '@slangroom/core/package.json' with { type: 'json' };
+import { errorColor } from '@slangroom/shared';
 
 /**
  * A whitespace-separated string of characters with position information.
@@ -90,7 +91,7 @@ export class LexError extends Error {
 	constructor(t: Token) {
 		super();
 		this.name = 'LexError @slangroom/core@' + packageJson.version;
-		this.message = `at ${t.lineNo}:${t.start + 1}-${t.end + 1}\n unclosed single-quote \x1b[31m${t.raw}\x1b[0m`;
+		this.message = `at ${t.lineNo}:${t.start + 1}-${t.end + 1}\n unclosed single-quote ${errorColor(t.raw)}`;
 	}
 }
 

--- a/pkg/core/src/parser.ts
+++ b/pkg/core/src/parser.ts
@@ -3,13 +3,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { PluginMap, Token, type PluginMapKey } from '@slangroom/core';
+import { errorColor, suggestedColor, missingColor, extraColor } from '@slangroom/shared';
 // read the version from the package.json
 import packageJson from '@slangroom/core/package.json' with { type: 'json' };
-
-export const errorColor = (s: string): string => '\x1b[31m' + s + '\x1b[0m';
-export const suggestedColor = (s: string): string => '\x1b[32m' + s + '\x1b[0m';
-export const missingColor = (s: string): string => '\x1b[36m' + s + '\x1b[0m';
-export const extraColor = (s: string): string => '\x1b[35m' + s + '\x1b[0m';
 
 /**
  * Represents an error encountered during the parsing phrase.

--- a/pkg/core/src/slangroom.ts
+++ b/pkg/core/src/slangroom.ts
@@ -5,8 +5,15 @@
 import { getIgnoredStatements } from '@slangroom/ignored';
 import { type ZenOutput, ZenParams, zencodeExec } from '@slangroom/shared';
 import { lex, parse, visit, Plugin, PluginMap, PluginContextImpl } from '@slangroom/core';
-// error colors
-import { errorColor, suggestedColor, missingColor, extraColor } from '@slangroom/core';
+import {
+	sentenceHighlight,
+	textHighlight,
+	errorColor,
+	suggestedColor,
+	missingColor,
+	extraColor,
+	lineNoColor
+} from '@slangroom/shared';
 
 /**
  * Just a utility type to ease typing.
@@ -149,11 +156,11 @@ const thorwErrors = (errorArray: GenericError[], contract: string) => {
 	for (let i = lineStart; i < lineEnd; i++) {
 		const linePrefix = `${i} | `;
 		if (i === lineNumber -1) {
-			let bold = '\x1b[1;30m' + contractLines[i]!.slice(colStart, colEnd) + '\x1b[0m' + '\x1b[41m';
-			const redBackground = '\x1b[41m' + contractLines[i]!.slice(0, colStart) + bold + contractLines[i]!.slice(colEnd) + '\x1b[0m';
-			e = e.concat(`\x1b[33m${linePrefix}\x1b[0m${redBackground}\n`);
-			e = e.concat(' '.repeat(colStart + linePrefix.length) + '\x1b[31m' + '^'.repeat(colEnd - colStart) + '\x1b[0m', '\n');
-		} else { e = e.concat(`\x1b[33m${linePrefix}\x1b[0m${contractLines[i]}\n`); }
+			let boldError = textHighlight(contractLines[i]!.slice(colStart, colEnd));
+			const redBackground = sentenceHighlight(contractLines[i]!.slice(0, colStart) + boldError + contractLines[i]!.slice(colEnd));
+			e = e.concat(`${lineNoColor(linePrefix)}${redBackground}\n`);
+			e = e.concat(' '.repeat(colStart + linePrefix.length) + errorColor('^'.repeat(colEnd - colStart)) + '\n');
+		} else { e = e.concat(`${lineNoColor(linePrefix)}${contractLines[i]}\n`); }
 	}
 	e = e.concat('\n' + 'Error colors:\n');
 	e = e.concat(` - ${errorColor('error')}\n`);

--- a/pkg/core/test/errors.ts
+++ b/pkg/core/test/errors.ts
@@ -3,8 +3,15 @@ import { Plugin, Slangroom } from '@slangroom/core';
 import test from 'ava';
 // read the version from the package.json
 import packageJson from '@slangroom/core/package.json' with { type: 'json' };
-// error colors
-import { errorColor, suggestedColor, missingColor, extraColor } from '@slangroom/core';
+import {
+	sentenceHighlight,
+	textHighlight,
+	errorColor,
+	suggestedColor,
+	missingColor,
+	extraColor,
+	lineNoColor
+} from '@slangroom/shared';
 
 
 test('@slangroom/core errors are shown and context is shown with line number', async (t) => {
@@ -17,11 +24,11 @@ test('@slangroom/core errors are shown and context is shown with line number', a
     Given nothing
     Then print data`)
 
-    const expected = `\x1b[33m0 | \x1b[0mRule unknown ignore
-\x1b[33m1 | \x1b[0m\x1b[41m    Given I \x1b[1;30mgibberish\x1b[0m\x1b[41m\x1b[0m
-                \x1b[31m^^^^^^^^^\x1b[0m
-\x1b[33m2 | \x1b[0m    Given nothing
-\x1b[33m3 | \x1b[0m    Then print data
+    const expected = `${lineNoColor('0 | ')}Rule unknown ignore
+${lineNoColor('1 | ')}${sentenceHighlight(`    Given I ${textHighlight('gibberish')}`)}
+                ${errorColor('^^^^^^^^^')}
+${lineNoColor('2 | ')}    Given nothing
+${lineNoColor('3 | ')}    Then print data
 
 Error colors:
  - ${errorColor('error')}
@@ -65,11 +72,11 @@ test('@slangroom/core lexer error', async (t) => {
     Given nothing
     Then print data`)
 
-    const expected = `\x1b[33m0 | \x1b[0mRule unknown ignore
-\x1b[33m1 | \x1b[0m\x1b[41m    Given I send param \x1b[1;30m'param and do some action\x1b[0m\x1b[41m\x1b[0m
-                           \x1b[31m^^^^^^^^^^^^^^^^^^^^^^^^^\x1b[0m
-\x1b[33m2 | \x1b[0m    Given nothing
-\x1b[33m3 | \x1b[0m    Then print data
+    const expected = `${lineNoColor('0 | ')}Rule unknown ignore
+${lineNoColor('1 | ')}${sentenceHighlight(`    Given I send param ${textHighlight('\'param and do some action')}`)}
+                           ${errorColor('^^^^^^^^^^^^^^^^^^^^^^^^^')}
+${lineNoColor('2 | ')}    Given nothing
+${lineNoColor('3 | ')}    Then print data
 
 Error colors:
  - ${errorColor('error')}
@@ -96,11 +103,11 @@ test('@slangroom/core parser error does not start with given', async (t) => {
     Given nothing
     Then print data`)
 
-    const expected = `\x1b[33m0 | \x1b[0mRule unknown ignore
-\x1b[33m1 | \x1b[0m\x1b[41m    \x1b[1;30mGibberish\x1b[0m\x1b[41m connect to 'url' and send param 'param' and do some action and aoibndwebnd\x1b[0m
-        \x1b[31m^^^^^^^^^\x1b[0m
-\x1b[33m2 | \x1b[0m    Given nothing
-\x1b[33m3 | \x1b[0m    Then print data
+    const expected = `${lineNoColor('0 | ')}Rule unknown ignore
+${lineNoColor('1 | ')}${sentenceHighlight(`    ${textHighlight('Gibberish')} connect to 'url' and send param 'param' and do some action and aoibndwebnd`)}
+        ${errorColor('^^^^^^^^^')}
+${lineNoColor('2 | ')}    Given nothing
+${lineNoColor('3 | ')}    Then print data
 
 Error colors:
  - ${errorColor('error')}

--- a/pkg/core/test/lexer.ts
+++ b/pkg/core/test/lexer.ts
@@ -4,6 +4,7 @@
 
 import test from 'ava';
 import { lex, Token } from '@slangroom/core';
+import { errorColor } from '@slangroom/shared';
 
 test('lexer works', (t) => {
 	Object.entries<Token[][]>({
@@ -136,7 +137,7 @@ test('lexer works', (t) => {
 
 	const res = lex("When I encrypt the secret message 'message", 1);
 	if (res.ok) throw new Error("Lex fail to dectect unclosed single-quote");
-	t.is(res.error.message.message as string, `at 1:35-42\n unclosed single-quote \x1b[31m'message\x1b[0m`);
+	t.is(res.error.message.message as string, `at 1:35-42\n unclosed single-quote ${errorColor('\'message')}`);
 });
 
 test('token constructor erros', (t) => {

--- a/pkg/deps/package.json
+++ b/pkg/deps/package.json
@@ -2,6 +2,7 @@
 	"name": "@slangroom/deps",
 	"version": "1.32.1",
 	"dependencies": {
+		"chalk": "^5.3.0",
 		"chevrotain": "^10.5.0"
 	},
 	"peerDependencies": {

--- a/pkg/deps/src/chalk.ts
+++ b/pkg/deps/src/chalk.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2024 Dyne.org foundation
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export { default } from 'chalk';

--- a/pkg/shared/src/colors.ts
+++ b/pkg/shared/src/colors.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024 Dyne.org foundation
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import chalk from '@slangroom/deps/chalk';
+
+export const sentenceHighlight = chalk.bgRed;
+export const textHighlight = chalk.bold;
+
+export const errorColor = chalk.red;
+export const suggestedColor = chalk.green;
+export const missingColor = chalk.cyan;
+export const extraColor = chalk.magenta;
+export const lineNoColor = chalk.yellow;

--- a/pkg/shared/src/index.ts
+++ b/pkg/shared/src/index.ts
@@ -5,3 +5,4 @@
 export * from '@slangroom/shared/jsonable';
 export * from '@slangroom/shared/tokens';
 export * from '@slangroom/shared/zenroom';
+export * from '@slangroom/shared/colors';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
 
   pkg/deps:
     dependencies:
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
       chevrotain:
         specifier: ^10.5.0
         version: 10.5.0


### PR DESCRIPTION
- chore: import chalk in @slangroom/deps and expose error coloring and formatting functions from @slagnroom/shared
- fix: use chalk to style error message insted of using directly ansi escape codes
