### PR TITLE
chore: add required node engine for all plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
-    "ava": "^6.1.2",
+    "ava": "^6.1.3",
     "c8": "^9.1.0",
     "esbuild": "^0.20.2",
     "eslint": "^8.57.0",
@@ -40,5 +40,8 @@
     "typedoc": "^0.25.12",
     "typescript": "5.4.3",
     "vitepress": "^1.0.1"
+  },
+  "engines": {
+	"node": "^18.20.0 || ^20.10.0 || ^22"
   }
 }

--- a/pkg/browser/package.json
+++ b/pkg/browser/package.json
@@ -41,5 +41,8 @@
 	},
 	"scripts": {
 		"build": "pnpm exec esbuild --bundle src/index.ts --outfile=build/slangroom.js --target=es2016 --external:fs --external:path --external:crypto && cp build/slangroom.js public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/core/package.json
+++ b/pkg/core/package.json
@@ -28,5 +28,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/db/package.json
+++ b/pkg/db/package.json
@@ -28,5 +28,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/deps/package.json
+++ b/pkg/deps/package.json
@@ -28,5 +28,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/ethereum/package.json
+++ b/pkg/ethereum/package.json
@@ -30,5 +30,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/fs/package.json
+++ b/pkg/fs/package.json
@@ -37,5 +37,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/git/package.json
+++ b/pkg/git/package.json
@@ -35,5 +35,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/helpers/package.json
+++ b/pkg/helpers/package.json
@@ -29,5 +29,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/http/package.json
+++ b/pkg/http/package.json
@@ -28,5 +28,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/ignored/package.json
+++ b/pkg/ignored/package.json
@@ -27,5 +27,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/json-schema/package.json
+++ b/pkg/json-schema/package.json
@@ -28,5 +28,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/oauth/package.json
+++ b/pkg/oauth/package.json
@@ -30,5 +30,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/pocketbase/package.json
+++ b/pkg/pocketbase/package.json
@@ -31,5 +31,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/qrcode/package.json
+++ b/pkg/qrcode/package.json
@@ -30,5 +30,8 @@
 	},
 	"devDependencies": {
 		"@types/qrcode": "^1.5.5"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/redis/package.json
+++ b/pkg/redis/package.json
@@ -28,5 +28,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/shared/package.json
+++ b/pkg/shared/package.json
@@ -25,5 +25,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/shell/package.json
+++ b/pkg/shell/package.json
@@ -27,5 +27,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/timestamp/package.json
+++ b/pkg/timestamp/package.json
@@ -26,5 +26,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/wallet/package.json
+++ b/pkg/wallet/package.json
@@ -31,5 +31,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pkg/zencode/package.json
+++ b/pkg/zencode/package.json
@@ -27,5 +27,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"engines": {
+	  "node": "^18.20.0 || ^20.10.0 || ^22"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^7.4.0
         version: 7.4.0(eslint@8.57.0)(typescript@5.4.3)
       ava:
-        specifier: ^6.1.2
-        version: 6.1.2(encoding@0.1.13)
+        specifier: ^6.1.3
+        version: 6.1.3(encoding@0.1.13)
       c8:
         specifier: ^9.1.0
         version: 9.1.0
@@ -1561,6 +1561,7 @@ packages:
   are-we-there-yet@2.0.0:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
@@ -1607,9 +1608,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  ava@6.1.2:
-    resolution: {integrity: sha512-WcpxJ8yZ7mk9ABTinD0IAjcemovSeVGjuuwZx0JS9johREWFeLTl8UP6wd7l6nmnrWqkKZdwaD71a/ocH4qPKw==}
-    engines: {node: ^18.18 || ^20.8 || ^21}
+  ava@6.1.3:
+    resolution: {integrity: sha512-tkKbpF1pIiC+q09wNU9OfyTDYZa8yuWvU2up3+lFJ3lr1RmnYh2GBpPwzYUEB0wvTPIUysGjcZLNZr7STDviRA==}
+    engines: {node: ^18.18 || ^20.8 || ^21 || ^22}
     hasBin: true
     peerDependencies:
       '@ava/typescript': '*'
@@ -2317,6 +2318,7 @@ packages:
   gauge@3.0.2:
     resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
@@ -3136,6 +3138,7 @@ packages:
 
   npmlog@5.0.1:
     resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
@@ -5584,7 +5587,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  ava@6.1.2(encoding@0.1.13):
+  ava@6.1.3(encoding@0.1.13):
     dependencies:
       '@vercel/nft': 0.26.4(encoding@0.1.13)
       acorn: 8.11.3


### PR DESCRIPTION
- chore: add required node engine for all plugins
- chore: bump ava to 6.1.3 that added support for node 22
