### PR TITLE
ci: use node 22.2.0 instead of current during tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        node: [ lts/*, current ]
+        node: [ lts/*, 22.2.0 ]
 
     steps:
       - name: 🛠️ Prepare pnpm workspace


### PR DESCRIPTION
node 22.3.0 breaks isomorphic-git, already opened an issue over there, as soon as possible will use again current node version for testing
