### PR TITLE
refactor(rdf): replace rdfjs-c14n with rdf-canonize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@
 !/pkg/*/test/**/*.ts
 !/pkg/*/package.json
 !/pkg/*/pnpm-lock.yaml
+!/pkg/*/types/**/*.d.ts
 !/pkg/*/tsconfig.json
 !/pkg/*/.npmignore
 

--- a/pkg/rdf/package.json
+++ b/pkg/rdf/package.json
@@ -4,8 +4,7 @@
 	"dependencies": {
 		"@slangroom/core": "workspace:*",
 		"jsonld": "^8.3.3",
-		"n3": "^1.24.2",
-		"rdfjs-c14n": "^3.1.3"
+		"rdf-canonize": "^4.0.1"
 	},
 	"repository": "https://github.com/dyne/slangroom",
 	"license": "AGPL-3.0-only",
@@ -35,6 +34,6 @@
 	},
 	"devDependencies": {
 		"@types/jsonld": "^1.5.15",
-		"@types/n3": "^1.24.2"
+		"@types/node": "^24.0.3"
 	}
 }

--- a/pkg/rdf/tsconfig.json
+++ b/pkg/rdf/tsconfig.json
@@ -1,1 +1,52 @@
-../../tsconfig.json
+{
+	"include": [
+		"src/**/*",
+		"test/**/*"
+	],
+	"compilerOptions": {
+		"typeRoots": [
+			"./types"
+		],
+		"rootDir": ".",
+		"paths": {
+			"rdf-canonize": [
+				"./types/rdf-canonize"
+			]
+		},
+		"target": "ESNext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"incremental": true,
+		"newLine": "lf",
+		"declaration": true,
+		"forceConsistentCasingInFileNames": true,
+		"allowUnreachableCode": false,
+		"allowUnusedLabels": false,
+		"alwaysStrict": true,
+		"exactOptionalPropertyTypes": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitAny": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noImplicitThis": true,
+		"noPropertyAccessFromIndexSignature": true, // maybe
+		"noUncheckedIndexedAccess": true, // maybe
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"strict": true, // for the future versions
+		"strictBindCallApply": true,
+		"strictFunctionTypes": true,
+		"strictNullChecks": true,
+		"strictPropertyInitialization": true,
+		"useUnknownInCatchVariables": false,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"experimentalDecorators": true,
+		"sourceMap": true,
+		"lib": [
+			"es6",
+			"dom",
+			"es2021"
+		]
+	}
+}

--- a/pkg/rdf/types/rdf-canonize.d.ts
+++ b/pkg/rdf/types/rdf-canonize.d.ts
@@ -1,0 +1,44 @@
+// types/rdf-canonize.d.ts
+
+declare module 'rdf-canonize' {
+  /**
+   * Canonization algorithm identifiers
+   */
+  export type Algorithm = 'RDFC-1.0' | 'URDNA2015';
+
+  /**
+   * Options for the canonize function
+   */
+  export interface CanonizeOptions {
+    algorithm?: Algorithm;
+    inputFormat?: string;
+    useNative?: boolean;
+  }
+
+  /**
+   * Minimal RDF term structure
+   */
+  export interface Term {
+    termType: 'NamedNode' | 'BlankNode' | 'Literal' | 'DefaultGraph';
+    value: string;
+  }
+
+  /**
+   * Minimal RDF quad structure
+   */
+  export interface Quad {
+    subject: Term;
+    predicate: Term;
+    object: Term;
+    graph: Term;
+  }
+
+  /**
+   * Canonizes RDF dataset or N-Quads string.
+   * Returns canonical N-Quads string.
+   */
+  export function canonize(
+    input: Quad[] | string,
+    options?: CanonizeOptions
+  ): Promise<string>;
+}

--- a/pkg/rdf/types/rdf-canonize.d.ts
+++ b/pkg/rdf/types/rdf-canonize.d.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 Dyne.org foundation
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
 // types/rdf-canonize.d.ts
 
 declare module 'rdf-canonize' {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,19 +492,16 @@ importers:
       jsonld:
         specifier: ^8.3.3
         version: 8.3.3(web-streams-polyfill@3.3.3)
-      n3:
-        specifier: ^1.24.2
-        version: 1.24.2
-      rdfjs-c14n:
-        specifier: ^3.1.3
-        version: 3.1.3
+      rdf-canonize:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@types/jsonld':
         specifier: ^1.5.15
         version: 1.5.15
-      '@types/n3':
-        specifier: ^1.24.2
-        version: 1.24.2
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.3
 
   pkg/redis:
     dependencies:
@@ -1420,9 +1417,6 @@ packages:
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
 
-  '@rdfjs/types@1.1.2':
-    resolution: {integrity: sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==}
-
   '@redis/client@1.5.12':
     resolution: {integrity: sha512-/ZjE18HRzMd80eXIIUIPcH81UoZpwulbo8FmbElrjPqH0QC0SeIKu1BOU49bO5trM5g895kAjhvalt5h77q+4A==}
     engines: {node: '>=14'}
@@ -1724,9 +1718,6 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/n3@1.24.2':
-    resolution: {integrity: sha512-clurEPFqgx68kQxCBCrAUppsvZyyj/uVEgbhquYaawTZuDptrRrnFsHIWd4PubwWCfFgyrHBgaB2Tt09TTYLWw==}
-
   '@types/node@20.17.32':
     resolution: {integrity: sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==}
 
@@ -1735,6 +1726,9 @@ packages:
 
   '@types/node@22.7.6':
     resolution: {integrity: sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==}
+
+  '@types/node@24.0.3':
+    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2086,9 +2080,6 @@ packages:
 
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
-
-  array-permutation@0.2.0:
-    resolution: {integrity: sha512-+4hZ4IIKyeDWXPTnCMlo45tk6qHGgC1pCh7yP7FaerrU08omhrnueOdXIMGLp4etKilZfOC/046eodZEOxegIA==}
 
   array-union@3.0.1:
     resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
@@ -2808,9 +2799,6 @@ packages:
 
   ethereum-cryptography@2.1.2:
     resolution: {integrity: sha512-Z5Ba0T0ImZ8fqXrJbpHcbpAvIswRte2wGNR/KePnu8GbbvgJ47lMxT/ZZPG6i9Jaht4azPDop4HaM00J0J59ug==}
-
-  event-emitter-promisify@1.1.0:
-    resolution: {integrity: sha512-uyHG8gjwYGDlKoo0Txtx/u1HI1ubj0FK0rVqI4O0s1EymQm4iAEMbrS5B+XFlSaS8SZ3xzoKX+YHRZk8Nk/bXg==}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -3926,10 +3914,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  n3@1.24.2:
-    resolution: {integrity: sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==}
-    engines: {node: '>=12.0'}
-
   nanoid@3.3.1:
     resolution: {integrity: sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4544,9 +4528,9 @@ packages:
     resolution: {integrity: sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==}
     engines: {node: '>=12'}
 
-  rdfjs-c14n@3.1.3:
-    resolution: {integrity: sha512-1ihYqiJ8VH6ZC/anYEHhQcsFRKalkqxtApOI6txNmvofgpj1+Mifhz+YvGbf/KEMPhBxSOpC9/LWXp2qjv0+jg==}
-    engines: {node: '>=21.0.0'}
+  rdf-canonize@4.0.1:
+    resolution: {integrity: sha512-B5ynHt4sasbUafzrvYI2GFARgeFcD8Sx9yXPbg7gEyT2EH76rlCv84kyO6tnxzVbxUN/uJDbK1S/MXh+DsnuTA==}
+    engines: {node: '>=18'}
 
   read-cmd-shim@4.0.0:
     resolution: {integrity: sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q==}
@@ -5193,6 +5177,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
@@ -6614,10 +6601,6 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@rdfjs/types@1.1.2':
-    dependencies:
-      '@types/node': 22.15.3
-
   '@redis/client@1.5.12':
     dependencies:
       cluster-key-slot: 1.1.2
@@ -6945,11 +6928,6 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/n3@1.24.2':
-    dependencies:
-      '@rdfjs/types': 1.1.2
-      '@types/node': 22.15.3
-
   '@types/node@20.17.32':
     dependencies:
       undici-types: 6.19.8
@@ -6961,6 +6939,10 @@ snapshots:
   '@types/node@22.7.6':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/node@24.0.3':
+    dependencies:
+      undici-types: 7.8.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -7383,8 +7365,6 @@ snapshots:
   array-find-index@1.0.2: {}
 
   array-ify@1.0.0: {}
-
-  array-permutation@0.2.0: {}
 
   array-union@3.0.1: {}
 
@@ -8189,8 +8169,6 @@ snapshots:
       '@noble/hashes': 1.3.1
       '@scure/bip32': 1.3.1
       '@scure/bip39': 1.2.1
-
-  event-emitter-promisify@1.1.0: {}
 
   event-target-shim@5.0.1: {}
 
@@ -9347,12 +9325,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  n3@1.24.2:
-    dependencies:
-      buffer: 6.0.3
-      queue-microtask: 1.2.3
-      readable-stream: 4.7.0
-
   nanoid@3.3.1: {}
 
   nanoid@3.3.7: {}
@@ -9889,13 +9861,9 @@ snapshots:
     dependencies:
       setimmediate: 1.0.5
 
-  rdfjs-c14n@3.1.3:
+  rdf-canonize@4.0.1:
     dependencies:
-      '@rdfjs/types': 1.1.2
-      array-permutation: 0.2.0
-      event-emitter-promisify: 1.1.0
-      n3: 1.24.2
-      yaml: 2.6.0
+      setimmediate: 1.0.5
 
   read-cmd-shim@4.0.0: {}
 
@@ -10587,6 +10555,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.8.0: {}
 
   undici@5.29.0:
     dependencies:


### PR DESCRIPTION
This commit replaces the `rdfjs-c14n` library with `rdf-canonize`
for RDF canonicalization. This change simplifies the code and
updates dependencies.
